### PR TITLE
Version bump to 0.2.0 for node-red-teknoir-visualize.

### DIFF
--- a/catalogue.json
+++ b/catalogue.json
@@ -140,9 +140,9 @@
       "types": [
         "visualize"
       ],
-      "updated_at": "2023-10-23T19:47:53.251Z",
+      "updated_at": "2024-06-06T14:05:53.251Z",
       "id": "node-red-teknoir-visualize",
-      "version": "teknoir/node-red-teknoir-visualize#0.1.0",
+      "version": "teknoir/node-red-teknoir-visualize#0.2.0",
       "url": "https://github.com/teknoir/node-red-teknoir-visualize"
     },
     {


### PR DESCRIPTION
### Overview
Tag exists for [0.2.0](https://github.com/teknoir/node-red-teknoir-visualize/tree/0.2.0)