### PR TITLE
Version bump to 0.2.2 for node-red-teknoir-visualize.

### DIFF
--- a/catalogue.json
+++ b/catalogue.json
@@ -140,9 +140,9 @@
       "types": [
         "visualize"
       ],
-      "updated_at": "2024-08-02T10:27:53.251Z",
+      "updated_at": "2024-11-04T11:45:53.251Z",
       "id": "node-red-teknoir-visualize",
-      "version": "teknoir/node-red-teknoir-visualize#0.2.1",
+      "version": "teknoir/node-red-teknoir-visualize#0.2.2",
       "url": "https://github.com/teknoir/node-red-teknoir-visualize"
     },
     {


### PR DESCRIPTION
### Overview
Tag exists for [0.2.2](https://github.com/teknoir/node-red-teknoir-visualize/tree/0.2.2)